### PR TITLE
Implement credits section, accordion improvements, icons for movie detaila

### DIFF
--- a/src/components/movieDetails/index.tsx
+++ b/src/components/movieDetails/index.tsx
@@ -15,6 +15,9 @@ import { Link } from "react-router-dom";
 import { Card, CardContent, CardMedia } from "@mui/material";
 import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
 import { ExpandMore } from "@mui/icons-material";
+import TheaterComedyOutlinedIcon from "@mui/icons-material/TheaterComedyOutlined";
+import CameraIndoorOutlinedIcon from "@mui/icons-material/CameraIndoorOutlined";
+import LocalMoviesIcon from "@mui/icons-material/LocalMovies";
 
 const styles = {
   chipSet: {
@@ -37,10 +40,11 @@ const styles = {
   similarMoviesBox: {
     maxWidth: "100%",
     overflowX: "auto",
+    overflowY: "hidden",
     whiteSpace: "nowrap",
     paddingY: "10px",
   },
-  similarMovieCard: {
+  genericCard: {
     display: "inline-block",
     margin: "0 10px",
     textAlign: "center",
@@ -53,11 +57,36 @@ const styles = {
       boxShadow: "0 8px 16px rgba(0, 0, 0, 0)",
     },
   },
+  similarMovieImage: {
+    width: "100%",
+    height: "300px",
+    objectFit: "cover",
+    borderRadius: "8px",
+  },
+  creditsImage: {
+    borderRadius: "8px",
+  },
+  cardTitle: {
+    marginBottom: "5px",
+  },
+  cardSubtitle: {},
 };
 
 const MovieDetails: React.FC<MovieDetailsProps> = (movie) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  // https://mui.com/material-ui/react-accordion/
+  const [expanded, setExpanded] = useState<string | false>(false);
+
+  const handleChange =
+    (panel: string) => (event: React.SyntheticEvent, isExpanded: boolean) => {
+      setExpanded(isExpanded ? panel : false);
+    };
+
+  const ids = new Set();
+  const uniqueCrewList = movie.credits.crew.filter(
+    ({ id }) => !ids.has(id) && ids.add(id)
+  );
   return (
     <>
       <Typography variant="h5" component="h3">
@@ -107,28 +136,121 @@ const MovieDetails: React.FC<MovieDetailsProps> = (movie) => {
         <MovieReviews {...movie} />
       </Drawer>
       <>
-        <Accordion>
+        <Accordion
+          disableGutters
+          expanded={expanded === "panel1"}
+          onChange={handleChange("panel1")}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMore />}
+            aria-controls="cast-content"
+            id="cast-header"
+          >
+            <TheaterComedyOutlinedIcon />
+            <Typography variant="h5">Cast</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Box sx={styles.genericBox}>
+              {movie.credits.cast
+                // The below filters out any actor without a profile_path (picture)
+                .filter((actor) => actor.profile_path)
+                .map((actor) => (
+                  <Link key={actor.id} to={`/person/${actor.id}`}>
+                    <Card sx={{ ...styles.genericCard, width: 200 }}>
+                      <Typography
+                        variant="h6"
+                        component="div"
+                        sx={styles.cardTitle}
+                      >
+                        {actor.name}
+                      </Typography>
+                      <CardMedia
+                        component="img"
+                        image={`https://image.tmdb.org/t/p/w200${actor.profile_path}`}
+                        alt={movie.title}
+                        style={styles.creditsImage}
+                      />
+                      <CardContent>
+                        <Typography variant="body2" style={styles.cardSubtitle}>
+                          {actor.character}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                ))}
+            </Box>
+          </AccordionDetails>
+        </Accordion>
+        <Accordion
+          disableGutters
+          expanded={expanded === "panel2"}
+          onChange={handleChange("panel2")}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMore />}
+            aria-controls="crew-content"
+            id="crew-header"
+          >
+            <CameraIndoorOutlinedIcon />
+            <Typography variant="h5">Crew</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Box sx={styles.genericBox}>
+              {uniqueCrewList
+                .filter((crewMember) => crewMember.profile_path)
+                .map((crewMember) => (
+                  <Link key={crewMember.id} to={`/person/${crewMember.id}`}>
+                    <Card sx={{ ...styles.genericCard, width: 200 }}>
+                      <Typography
+                        variant="h6"
+                        component="div"
+                        sx={styles.cardTitle}
+                      >
+                        {crewMember.name}
+                      </Typography>
+                      <CardMedia
+                        component="img"
+                        image={`https://image.tmdb.org/t/p/w200${crewMember.profile_path}`}
+                        alt={movie.title}
+                        style={styles.creditsImage}
+                      />
+                      <CardContent>
+                        <Typography variant="body2" style={styles.cardSubtitle}>
+                          {crewMember.job}
+                        </Typography>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                ))}
+            </Box>
+          </AccordionDetails>
+        </Accordion>
+        <Accordion
+          disableGutters
+          expanded={expanded === "panel3"}
+          onChange={handleChange("panel3")}
+        >
           <AccordionSummary
             expandIcon={<ExpandMore />}
             aria-controls="panel2-content"
             id="panel2-header"
           >
+            <LocalMoviesIcon />
             <Typography variant="h5">Similar Movies</Typography>
           </AccordionSummary>
           <AccordionDetails>
             {/* I referred to the movie detail page of https://github.com/ki321g/MovieAPP, modifying the code for similar movies instead of cast 
             I combined this with the accordion feature I saw in https://github.com/eoinfennessy/movies-app/ */}
-            <Box sx={styles.similarMoviesBox}>
+            <Box sx={styles.genericBox}>
               {movie.similar.results
-                // The below filters out any movie without a profile_path (picture)
                 .filter((movie) => movie.poster_path)
                 .map((movie) => (
                   <Link key={movie.id} to={`/movies/${movie.id}`}>
-                    <Card sx={{ ...styles.similarMovieCard, width: 200 }}>
+                    <Card sx={{ ...styles.genericCard, width: 200 }}>
                       <Typography
                         variant="h6"
                         component="div"
-                        sx={styles.similarMovieTitle}
+                        sx={styles.cardTitle}
                       >
                         {movie.title}
                       </Typography>
@@ -136,13 +258,10 @@ const MovieDetails: React.FC<MovieDetailsProps> = (movie) => {
                         component="img"
                         image={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
                         alt={movie.title}
-                        style={styles.similarMovieImage}
+                        sx={styles.similarMovieImage}
                       />
                       <CardContent>
-                        <Typography
-                          variant="body2"
-                          style={styles.similarMovieInfo}
-                        >
+                        <Typography variant="body2" style={styles.cardSubtitle}>
                           {movie.vote_average}
                         </Typography>
                       </CardContent>


### PR DESCRIPTION
This pull request enhances the `MovieDetails` component in `src/components/movieDetails/index.tsx` by introducing new features for displaying cast, crew, and similar movies using expandable accordions. It also refactors styling and adds utility functions to improve code organization and user experience.

### Feature Enhancements:
* Added three expandable accordions (`Cast`, `Crew`, and `Similar Movies`) to organize and display movie-related data. Each accordion uses Material-UI's `Accordion` component with custom icons (`TheaterComedyOutlinedIcon`, `CameraIndoorOutlinedIcon`, and `LocalMoviesIcon`) for better visual distinction.
* Implemented filtering logic for cast and crew lists to ensure only unique entries with profile pictures are displayed. [[1]](diffhunk://#diff-3c29d16c91c305a81624077a50f803ce4c0f207501eac2ec8d38b3239a50f119R60-R89) [[2]](diffhunk://#diff-3c29d16c91c305a81624077a50f803ce4c0f207501eac2ec8d38b3239a50f119L110-R264)

### Styling Improvements:
* Refactored styles by introducing reusable style properties (`genericCard`, `creditsImage`, `cardTitle`, and `cardSubtitle`) and updating existing ones (`similarMoviesBox` and `genericBox`) for consistency across the component. [[1]](diffhunk://#diff-3c29d16c91c305a81624077a50f803ce4c0f207501eac2ec8d38b3239a50f119R43-R47) [[2]](diffhunk://#diff-3c29d16c91c305a81624077a50f803ce4c0f207501eac2ec8d38b3239a50f119R60-R89)
* Adjusted image styling for cast, crew, and similar movies to improve visual presentation, including `objectFit: cover` and rounded corners.

### Code Organization:
* Added a utility function (`handleChange`) to manage accordion state for expanded panels. This simplifies the logic for toggling accordion sections.